### PR TITLE
Allow disk encryption, fix volume check

### DIFF
--- a/templates/create.json.j2
+++ b/templates/create.json.j2
@@ -4,7 +4,13 @@
         "name": "{{ ecs_name }}",
         "imageRef": "{{ image_id }}",
         "root_volume": {
-{% if ecs_volumesize is defined and ecs_volumesize > 0 %}  
+{% if ecs_volume_encryption_cmkid is defined %}
+        "metadata": {
+            "__system__encrypted": "1",
+            "__system__cmkid": "{{ ecs_volume_encryption_cmkid }}"
+        },
+{% endif %}
+{% if ecs_volumesize is defined and ecs_volumesize|int > 0 %}  
             "size": "{{ ecs_volumesize }}",
 {% endif %}  
             "volumetype": "{{ ecs_volumetype }}"


### PR DESCRIPTION
Hi @eumel8 I implemented root_volume encryption support by setting `ecs_volume_encryption_cmkid` to the KMS `cmk_id`.
This also fix the ansible str->int conversion error in the volumesize check.
Would be happy if you could add this to a new release :-) 